### PR TITLE
Adopt "password-store" #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Or you could rsync your local copy of the rockstor-rpmbuild repository, over fro
 ```shell
 zypper install --no-recommends rpm-build
 ```
-**NOTE: Solution 1: deinstallation of busybox-gzip ...**
+**NOTE: Solution 1: de-installation of busybox-gzip ...**
 May be required (replaced by the full gzip).
 See: [pre-install gzip to avoid busybox-gzip via dependency](https://github.com/rockstor/rockstor-installer/issues/135)
 
 
 ## Build the RPM/SRPM
 
-Both the regular RPM, and its source variant (SRPM) can be build with a single command.
+Both the regular RPM, and its source variant (SRPM) can be built with a single command.
 
 ```shell
 # Current dir must be that of the spec file:

--- a/rockstor.spec
+++ b/rockstor.spec
@@ -47,6 +47,7 @@ BuildRequires: make
 BuildRequires: postgresql13
 BuildRequires: postgresql13-server
 BuildRequires: postgresql13-server-devel
+BuildRequires: password-store
 # Notes re Poetry for future consideration:
 # https://en.opensuse.org/openSUSE:Build_system_recipes#PEP517_style:
 # https://github.com/openSUSE/python-rpm-macros/blob/79041e9986dd5427d0bc1f66936092ddfe04533b/README.md#install-macros
@@ -119,6 +120,7 @@ Requires: haveged
 Requires: gcc
 Requires: gcc-c++
 Requires: make
+Requires: password-store
 %endif
 
 # TUMBLEWEED
@@ -182,6 +184,7 @@ Requires: haveged
 Requires: gcc
 Requires: gcc-c++
 Requires: make
+Requires: password-store
 %endif
 
 # rpm build notes (from man rpmbuild):
@@ -280,6 +283,14 @@ install -m 644 ./conf/30-rockstor-nginx-override.conf %{buildroot}/etc/systemd/s
 export LANG=C.UTF-8
 export PYTHONIOENCODING=utf8
 /usr/local/bin/poetry install --no-interaction --no-ansi > poetry-install.txt 2>&1
+
+# Ensure GNUPG is setup for 'pass' (Idempotent)
+/usr/bin/gpg --quick-generate-key --batch --passphrase '' rockstor@localhost || true
+# Init 'pass' in ~ using above GPG key, and generate Django SECRET_KEY
+# export Environment="PASSWORD_STORE_DIR=/root/.password-store"
+/usr/bin/pass init rockstor@localhost
+/usr/bin/pass generate --no-symbols --force python-keyring/rockstor/SECRET_KEY 100
+
 export DJANGO_SETTINGS_MODULE=settings
 /usr/local/bin/poetry run django-admin collectstatic --no-input --verbosity 1
 cd src/rockstor/


### PR DESCRIPTION
Align with rockstor-core changes regarding 'pass' adoption for secrets storage. Install via OS provided 'password-store'. See partner draft PR: https://github.com/rockstor/rockstor-core/pull/2756/files

## Includes
- Additional minimal setup of GNUPG & pass to enable %check scriptlet function as we need a running Django instance for our tests.
- BuildRequires 'password-store' OS package for 'pass': required for %check scriptlet.
- Requires 'password-store' OS package on all OS targets.
- Minor README.md typos.