### PR TITLE
Move build.sh execution from %posttrans to rockstor-build.service #61

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -226,21 +226,9 @@ sha256sum rockstor-jslibs.tar.gz > rockstor-jslibs.tar.gz.sha256sum
 
 %build
 # Defaults to e.g. '/usr/src/packages/BUILD/rockstor-core-4.5.2-0/
-
-# Install Poetry, a dependency management, packaging, and build system.
-# Uninstall legacy/transitional Poetry version of 1.1.15
-PATH="$HOME/.local/bin:$PATH"  # account for more constrained environments.
-if which poetry && poetry --version | grep -q "1.1.15"; then
-  echo "Poetry version 1.1.15 found - UNINSTALLING"
-  curl -sSL https://install.python-poetry.org | python3 - --uninstall
-fi
-# Install Poetry via PIPX as a global app
-# https://peps.python.org/pep-0668/#guide-users-towards-virtual-environments
-export PIPX_HOME=/opt/pipx  # virtual environment location, default ~/.local/pipx
-export PIPX_BIN_DIR=/usr/local/bin  # binary location for pipx-installed apps, default ~/.local/bin
-python3.11 -m pipx install poetry==1.7.1
-
-# create our poetry source distribution in ./dist/rockstor-4.5.2.tar.gz
+echo "'build' scriptlet PATH=${PATH}"
+# Poetry install assumed, as per rockstor-build.service / build.sh.
+# Create our poetry source distribution in ./dist/rockstor-4.5.2.tar.gz
 poetry build --format sdist
 # N.B. above build installs minimal .venv (via poetry.config) of around 21 MB.
 # see contents via: tar tvf ./dist/rockstor-4.5.2.tar.gz
@@ -267,6 +255,7 @@ touch %{buildroot}%{prefix}/rockstor/var/log/rockstor_systems_log_dir
 # _unitdir normally resolves to: /usr/lib/systemd/system
 # N.B. we could run a sed here on all our service files to honour prefix.
 # Main rocksor* service files.
+install -D -m 644 ./conf/rockstor-build.service %{buildroot}%{_unitdir}/%{name}-build.service
 install -D -m 644 ./conf/rockstor-pre.service %{buildroot}%{_unitdir}/%{name}-pre.service
 install -D -m 644 ./conf/rockstor.service %{buildroot}%{_unitdir}/%{name}.service
 install -D -m 644 ./conf/rockstor-bootstrap.service %{buildroot}%{_unitdir}/%{name}-bootstrap.service
@@ -276,23 +265,13 @@ install -m 644 ./conf/30-rockstor-nginx-override.conf %{buildroot}/etc/systemd/s
 
 %check
 # Run tests from inside build directory.
+echo "'check' scriptlet PATH=${PATH}"
 # Build full project .venv (via poetry.config) - installing all dependencies.
 # Around 60 MB more than minimum venv (21 MB) installed already by poetry build.
-# --quiet malfunctions prior to 1.2.0b1:
-# https://github.com/python-poetry/poetry/pull/5179
-# Resolve Python 3.6 Poetry issue re char \u2022: (bullet)
-# https://github.com/python-poetry/poetry/issues/3078
-export LANG=C.UTF-8
-export PYTHONIOENCODING=utf8
 /usr/local/bin/poetry install --no-interaction --no-ansi > poetry-install.txt 2>&1
 
-# Ensure GNUPG is setup for 'pass' (Idempotent)
-/usr/bin/gpg --quick-generate-key --batch --passphrase '' rockstor@localhost || true
-# Init 'pass' in ~ using above GPG key, and generate Django SECRET_KEY
-# export Environment="PASSWORD_STORE_DIR=/root/.password-store"
-/usr/bin/pass init rockstor@localhost
-/usr/bin/pass generate --no-symbols --force python-keyring/rockstor/SECRET_KEY 100
-
+# GNUPG & 'pass' setup assumed, as per rockstor-build.service / build.sh.
+export Environment="PASSWORD_STORE_DIR=/root/.password-store"
 export DJANGO_SETTINGS_MODULE=settings
 /usr/local/bin/poetry run django-admin collectstatic --no-input --verbosity 1
 cd src/rockstor/
@@ -341,7 +320,7 @@ cd src/rockstor/
 # $1 == 2 is before an update
 #
 # Stop all main rockstor services, irrespective of origin.
-/usr/bin/systemctl stop rockstor-bootstrap.service rockstor.service rockstor-pre.service
+/usr/bin/systemctl stop rockstor-bootstrap.service rockstor.service rockstor-pre.service rockstor-build.service
 #
 # Backup all static/config-backups contents; to be restored in posttrans scriptlet.
 if [ -d "%{prefix}/%{name}/static/config-backups" ]
@@ -365,7 +344,7 @@ rm --force --recursive %{prefix}/%{name}/eggs
 # https://en.opensuse.org/openSUSE:Systemd_packaging_guidelines#Unit_files
 # See: /usr/lib/rpm/macros.d/macros.systemd from systemd-rpm-macros
 # rpm --eval macro-name-here
-%service_add_pre rockstor-pre.service rockstor.service rockstor-bootstrap.service
+%service_add_pre rockstor-build.service rockstor-pre.service rockstor.service rockstor-bootstrap.service
 exit 0
 
 %post
@@ -391,7 +370,7 @@ update-alternatives --set pipx /usr/bin/pipx-3.11
 # enable/disable our units by default on package installation,
 # enforcing distribution, spin or administrator preset policy.
 # See: https://build.opensuse.org/package/show/home:rockstor:branches:Base:System/systemd-presets-branding-rockstor
-%service_add_post rockstor-pre.service rockstor.service rockstor-bootstrap.service
+%service_add_post rockstor-build.service rockstor-pre.service rockstor.service rockstor-bootstrap.service
 exit 0
 
 %preun
@@ -400,7 +379,7 @@ exit 0
 # $1 == 1 is before an update
 #
 # If uninstall, the following service macro disables and stops our services.
-%service_del_preun rockstor-pre.service rockstor.service rockstor-bootstrap.service
+%service_del_preun rockstor-build.service rockstor-pre.service rockstor.service rockstor-bootstrap.service
 exit 0
 
 %postun
@@ -412,7 +391,7 @@ exit 0
 
 # If units are not to be restarted, use % service_del_postun_without_restart
 # On uninstall the following service macro deletes our services, then does a 'systemctl daemon-reload'
-%service_del_postun_without_restart rockstor-pre.service rockstor.service rockstor-bootstrap.service
+%service_del_postun_without_restart rockstor-build.service rockstor-pre.service rockstor.service rockstor-bootstrap.service
 
 # Post uninstall we need to restart the nginx service as we removed our nginx override file.
 if [ "$1" = "0" ]; then  # uninstall so clean up build.sh generated files and other dynamic files.
@@ -443,24 +422,11 @@ exit 0
 # Last scriptlet to execute from old or new package versions.
 # Executed from new package version during install & upgrade similarly.
 #
-# Ensure Postgres DB format is sufficiently upgraded before invoking build.sh.
+# Ensure Postgres DB format is sufficiently upgraded prior to systemd services start.
 # Requires matching postgresqlXX-* dependencies to target format requested.
 # If a system currently uses an older DB format, the associated binaries are assumed.
 # "10 13" prepares Leap 15.3 4.1.0-0 installs, dup'ed to 15.4 4.6.1-0, for > 5.0.5-0.
 %{prefix}/%{name}/src/rockstor/scripts/db_upgrade.sh 10 13
-#
-# Run build.sh which:
-# 1. Installs Poetry to system via pipx.
-# 2. Uses Poetry to create .venv.
-# 3. if no jslibs dir exists:
-#        un-tar rockstor-jslibs.tar.gz
-# 4. Regenerates static dir via collectstatic.
-#
-# We have a minimal path available so add system poetry explicitly.
-PATH="/usr/local/bin:$PATH"
-export LANG=C.UTF-8
-cd %{prefix}/%{name}
-./build.sh
 #
 # Restore 'pre' scriptlet's config-backup-rpmsave files to static.
 if [ -d "%{prefix}/%{name}/config-backups-rpmsave" ]


### PR DESCRIPTION
Move the execution of build.sh from outside of the constraints of the rpm packaging system, to the level of OS orchestration: systemd.

## Includes:
- Removal of redundant Poetry install/update. We now assume this of our build host, and assert rockstor-build.service / build.sh as the sole source of truth for this.
- Simplify %check scriptlet by similarly removing redundancy re GNUPG & 'pass' setup/config. Referencing rockstor-build.service / build.sh for this build host assumption.

Fixes #61 