### PR TITLE
Remove dmraid as a dependency #79

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -113,7 +113,6 @@ Requires: sssd-tools
 Requires: sssd-ad
 Requires: sssd-ldap
 Requires: sssd-dbus
-Requires: dmraid
 Requires: libzmq5
 Requires: dbus-1-devel
 Requires: glib2-devel
@@ -178,7 +177,6 @@ Requires: sssd-tools
 Requires: sssd-ad
 Requires: sssd-ldap
 Requires: sssd-dbus
-Requires: dmraid
 Requires: libzmq5
 Requires: dbus-1-devel
 Requires: glib2-devel


### PR DESCRIPTION
Remove this now dated convenience dependency. There is no actual dependency here, and its default systemd service failure can be disconcerting for the vast majority of users.

Fixes #79 