### PR TITLE
Add 'hostname' as a requirement #76

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -121,6 +121,7 @@ Requires: gcc
 Requires: gcc-c++
 Requires: make
 Requires: password-store
+Requires: hostname
 %endif
 
 # TUMBLEWEED
@@ -185,6 +186,7 @@ Requires: gcc
 Requires: gcc-c++
 Requires: make
 Requires: password-store
+Requires: hostname
 %endif
 
 # rpm build notes (from man rpmbuild):


### PR DESCRIPTION
Required/used in the final stage of initialising email notifications.

Fixes #76 