### PR TITLE
Tumbleweed dnf-plugins-core 'Not installable' #84

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -164,8 +164,8 @@ Requires: nut-drivers-net
 Requires: net-snmp
 Requires: docker
 Requires: cryptsetup
-Requires: dnf-yum
-Requires: dnf-plugins-core
+Requires: dnf5
+Requires: dnf5-plugins
 Requires: python3-python-dateutil
 Requires: which
 Requires: shellinabox


### PR DESCRIPTION
Address DNF4 to DNF5 transition in Tumbleweed, and presumably Slowroll to come. We use DNF/YUM for the ability to present changelogs of packages as-yet not installed. Predominantly 'rockstor' package update changelogs within the Web-UI.

With the above updates upstream we have a breaking change re dependencies that are no longer available: dnf-plugins-core.

Fix at least rpm install ability on TW, for which we use zypper exclusively, by updating the DNF related dependencies.

Fixes #84 

---

Caveat: as yet untested.