### PR TITLE
Update DB format from 13 to 17 re Django 5.2 compat #75

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -44,9 +44,9 @@ BuildRequires: glib2-devel
 BuildRequires: gcc
 BuildRequires: gcc-c++
 BuildRequires: make
-BuildRequires: postgresql13
-BuildRequires: postgresql13-server
-BuildRequires: postgresql13-server-devel
+BuildRequires: postgresql17
+BuildRequires: postgresql17-server
+BuildRequires: postgresql17-server-devel
 BuildRequires: password-store
 # Notes re Poetry for future consideration:
 # https://en.opensuse.org/openSUSE:Build_system_recipes#PEP517_style:
@@ -86,10 +86,11 @@ Requires: ntp
 Requires: at
 Requires: chrony
 Requires: firewalld
-Requires: postgresql13
-Requires: postgresql13-server
-Requires: postgresql13-server-devel
-Requires: postgresql13-contrib
+Requires: postgresql17
+Requires: postgresql17-devel
+Requires: postgresql17-server
+Requires: postgresql17-server-devel
+Requires: postgresql17-contrib
 Requires: rsync
 Requires: smartmontools
 Requires: hdparm
@@ -149,10 +150,11 @@ Requires: ntp
 Requires: at
 Requires: chrony
 Requires: firewalld
-Requires: postgresql13
-Requires: postgresql13-server
-Requires: postgresql13-server-devel
-Requires: postgresql13-contrib
+Requires: postgresql17
+Requires: postgresql17-devel
+Requires: postgresql17-server
+Requires: postgresql17-server-devel
+Requires: postgresql17-contrib
 Requires: rsync
 Requires: smartmontools
 Requires: hdparm
@@ -362,9 +364,9 @@ fi
 # Enforce, via manual alternatives configuration, our target postgresql & pipx versions.
 # We do this on install & update to avoid base OS defaults exceeding our compatibility.
 # Compatibility concerns:
-# - Postgresql: Django's secondary dependency of psycopg which we pin.
+# - Postgresql: Django 5.2's primary dependency on > 13, and secondary dependency of psycopg which we pin.
 # - Pipx: We install and manage Poetry via OS supplied python3.##-pipx packages.
-update-alternatives --set postgresql /usr/lib/postgresql13
+update-alternatives --set postgresql /usr/lib/postgresql17
 update-alternatives --set pipx /usr/bin/pipx-3.11
 # enable/disable our units by default on package installation,
 # enforcing distribution, spin or administrator preset policy.
@@ -426,6 +428,9 @@ exit 0
 # If a system currently uses an older DB format, the associated binaries are assumed.
 # "10 13" prepares Leap 15.3 4.1.0-0 installs, dup'ed to 15.4 4.6.1-0, for > 5.0.5-0.
 %{prefix}/%{name}/src/rockstor/scripts/db_upgrade.sh 10 13
+# The above is assumed to have been run in a previous update - upto Stable 5.1.0
+# Preparing for Stable 5.6.0-0 & Django 5.2 LTS and SSE potential. Leap 15.6 onwards.
+%{prefix}/%{name}/src/rockstor/scripts/db_upgrade.sh 13 17
 #
 # Restore 'pre' scriptlet's config-backup-rpmsave files to static.
 if [ -d "%{prefix}/%{name}/config-backups-rpmsave" ]


### PR DESCRIPTION
Djanog 5.2 has a minimum Postgres compatibility of 14. Three jumps from our prior 13 to 16 was considered, however there are known bugs in 16 re SSE, one of our pending aims. Ergo 17 was chosen as it is also available in our current OS targets of Leap 15.6 and TW/SR.

Adds another call to follow our existing `db_upgrade 10 13`, but as `db_upgrade 13 17`, along with a change to the existing update-alternatives to set a default of 17 for Postgres.

Fixes #75 

---

N.B. contains an as-yet unresolved re-submission of our last changelog. Suspeced as a change in line-ending character settings between my setup and our GitHub actions that prepares the changelog pull requests. No intended changes in that area bar EOL chars.