### PR TITLE
Add 'whois' as a requirement - provides 'mkpasswd' - a crypt front end #99

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -122,6 +122,7 @@ Requires: make
 Requires: password-store
 Requires: hostname
 Requires: sudo
+Requires: whois
 %endif
 
 # openSUSE Leap 16.0
@@ -185,6 +186,7 @@ Requires: make
 Requires: password-store
 Requires: hostname
 Requires: sudo
+Requires: whois
 %endif
 
 # TUMBLEWEED/Slowroll
@@ -250,6 +252,7 @@ Requires: make
 Requires: password-store
 Requires: hostname
 Requires: sudo
+Requires: whois
 %endif
 
 # rpm build notes (from man rpmbuild):


### PR DESCRIPTION
Required to replace the deprecated Python 'crypt' library that is similarly a crypt front front-end.

Fixes #99 