### PR TITLE
Missing runtime dependency - device-mapper #102

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -125,6 +125,7 @@ Requires: password-store
 Requires: hostname
 Requires: sudo
 Requires: whois
+Requires: device-mapper
 %endif
 
 # openSUSE Leap 16.0
@@ -190,6 +191,7 @@ Requires: password-store
 Requires: hostname
 Requires: sudo
 Requires: whois
+Requires: device-mapper
 %endif
 
 # TUMBLEWEED/Slowroll
@@ -257,6 +259,7 @@ Requires: password-store
 Requires: hostname
 Requires: sudo
 Requires: whois
+Requires: device-mapper
 %endif
 
 # rpm build notes (from man rpmbuild):


### PR DESCRIPTION
Provides `dmsetup`, required for LUKS device management. Assumed installed even if LUKS is not used: there-by providing the capability if required.

Fixes #102