### PR TITLE
Leap 16.0 dependency issue 'ypbind' #112

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -146,7 +146,7 @@ Requires: nfs-kernel-server
 Requires: nfs-client
 Requires: samba
 Requires: samba-winbind
-Requires: ypbind
+# Requires: ypbind  # No longer available.
 Requires: rpcbind
 Requires: realmd
 Requires: realmd-lang


### PR DESCRIPTION
Remove 'ypbind' as a dependency for Leap 16.0 only currently. This will break NIS service support for this target, but we plan to remove NIS for all targets in time.

Fixes #112 

---

Reference re NIS removal: https://github.com/rockstor/rockstor-core/issues/2947