### PR TITLE
Update rpm dependencies re legacy Py3.11 #118

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -200,14 +200,14 @@ Requires: lsb-release
 # As of Oct 2025:
 # Version unreliable as changes over time !
 %if 0%{?suse_version} > 1600
-BuildRequires: python311
-BuildRequires: python311-devel
-BuildRequires: python311-pipx
-BuildRequires: python311-rpm
-Requires: python311
-Requires: python311-devel
-Requires: python311-pipx
-Requires: python311-rpm
+BuildRequires: python313
+BuildRequires: python313-devel
+BuildRequires: python313-pipx
+BuildRequires: python313-rpm
+Requires: python313
+Requires: python313-devel
+Requires: python313-pipx
+Requires: python313-rpm
 Requires: NetworkManager
 Requires: nginx
 Requires: btrfsprogs


### PR DESCRIPTION
In Tumblweed & Slowroll we have yet to move our Python version dependency over to Py3.13. But given we have now successfully built against py3.13 on Leap 16.0, where there is no Py3.11, we can now move to Py3.13 on these OS targets: removing the need for Py3.11 entirely. It ramins in place on 15.6 as this is very near EOL and has no OS based Py3.13 option.

Fixes #118 