### PR TITLE
PyPi rpm shim needs fallback python3-rpm on Leap 15.6 #122

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -72,6 +72,7 @@ Requires: python311
 Requires: python311-devel
 Requires: python311-pipx
 Requires: python311-rpm
+Requires: python3-rpm
 Requires: NetworkManager
 Requires: nginx
 Requires: btrfsprogs


### PR DESCRIPTION
Add, for Leap < 16.0 only, python3-rpm as a work-around to supply the PyPi shim 'rpm' a fail-through option of the system Py3.6 version. Ideally we need the Py3.13 version but that is not available in Leap 15.6. Where-as it is in all our other OS targets.

As this concerns an EOL target we want to make as few changes as possible here to provide a fix. I.e. we have now some outdated dependencies around Py3.11, now that we use Poetry managed standalone Py3.13 but that is not the focus of this issue.

Fixes #122 