### PR TITLE
Remove Shellinabox dependency for all OS targets #130

### DIFF
--- a/rockstor.spec
+++ b/rockstor.spec
@@ -107,7 +107,6 @@ Requires: docker
 Requires: cryptsetup
 Requires: python3-python-dateutil
 Requires: which
-Requires: shellinabox
 Requires: avahi
 Requires: cronie
 Requires: sssd
@@ -174,7 +173,6 @@ Requires: docker
 Requires: cryptsetup
 Requires: python3-python-dateutil
 Requires: which
-# Requires: shellinabox  # OBS issue re "Nothing provides check-create-certificate"
 Requires: avahi
 Requires: cronie
 Requires: sssd
@@ -243,7 +241,6 @@ Requires: docker
 Requires: cryptsetup
 Requires: python3-python-dateutil
 Requires: which
-Requires: shellinabox
 Requires: avahi
 Requires: cronie
 Requires: sssd


### PR DESCRIPTION
Previously removed for only our Leap 16.0 target as a temporary move, we are now dropping this dependency entirely due to lack of upstream maintenance.

Fixes #130 